### PR TITLE
Fix panic when navigating from terminal dock

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -918,11 +918,14 @@ impl TerminalPanel {
         {
             window.focus(&pane.focus_handle(cx));
         } else {
-            self.workspace
-                .update(cx, |workspace, cx| {
-                    workspace.activate_pane_in_direction(direction, window, cx)
-                })
-                .ok();
+            let workspace = self.workspace.clone();
+            window.defer(cx, move |window, cx| {
+                workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.activate_pane_in_direction(direction, window, cx);
+                    })
+                    .ok();
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid double borrowing by deferring the workspace update
- use `update` instead of `update_in` to compile

## Testing
- `cargo check -p terminal_view` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_e_6839f7fd7208832ca1da518b45e22ae2