### PR TITLE
Fix panic when activating pane from terminal panel

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -918,11 +918,14 @@ impl TerminalPanel {
         {
             window.focus(&pane.focus_handle(cx));
         } else {
-            self.workspace
-                .update(cx, |workspace, cx| {
-                    workspace.activate_pane_in_direction(direction, window, cx)
-                })
-                .ok();
+            let workspace = self.workspace.clone();
+            window.defer(cx, move |window, cx| {
+                workspace
+                    .update_in(cx, |workspace, window, cx| {
+                        workspace.activate_pane_in_direction(direction, window, cx);
+                    })
+                    .ok();
+            });
         }
     }
 

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -62,6 +62,7 @@ telemetry.workspace = true
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
+rand.workspace = true
 uuid.workspace = true
 zed_actions.workspace = true
 workspace-hack.workspace = true

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -7,7 +7,7 @@ use gpui::{
     Action, AnyView, App, Axis, Context, Corner, Entity, EntityId, EventEmitter, FocusHandle,
     Focusable, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement,
     Render, SharedString, StyleRefinement, Styled, Subscription, WeakEntity, Window, deferred, div,
-    px,
+    px, Hsla,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -204,6 +204,8 @@ pub struct Dock {
     zoom_layer_open: bool,
     modal_layer: Entity<ModalLayer>,
     _subscriptions: [Subscription; 2],
+    #[cfg(debug_assertions)]
+    debug_color: Hsla,
 }
 
 impl Focusable for Dock {
@@ -280,6 +282,8 @@ impl Dock {
                 serialized_dock: None,
                 zoom_layer_open: false,
                 modal_layer,
+                #[cfg(debug_assertions)]
+                debug_color: crate::random_debug_color(),
             }
         });
 
@@ -786,6 +790,13 @@ impl Render for Dock {
                 .flex()
                 .bg(cx.theme().colors().panel_background)
                 .border_color(cx.theme().colors().border)
+                .when(
+                    cfg!(debug_assertions),
+                    |this| {
+                        this.border_2()
+                            .border_color(Color::Custom(self.debug_color))
+                    },
+                )
                 .overflow_hidden()
                 .map(|this| match self.position().axis() {
                     Axis::Horizontal => this.w(size).h_full().flex_row(),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -20,7 +20,7 @@ use gpui::{
     DragMoveEvent, Entity, EntityId, EventEmitter, ExternalPaths, FocusHandle, FocusOutEvent,
     Focusable, KeyContext, MouseButton, MouseDownEvent, NavigationDirection, Pixels, Point,
     PromptLevel, Render, ScrollHandle, Subscription, Task, WeakEntity, WeakFocusHandle, Window,
-    actions, anchored, deferred, impl_actions, prelude::*,
+    actions, anchored, deferred, impl_actions, prelude::*, Hsla,
 };
 use itertools::Itertools;
 use language::DiagnosticSeverity;
@@ -335,6 +335,8 @@ pub struct Pane {
     zoom_out_on_close: bool,
     /// If a certain project item wants to get recreated with specific data, it can persist its data before the recreation here.
     pub project_item_restoration_data: HashMap<ProjectItemKind, Box<dyn Any + Send>>,
+    #[cfg(debug_assertions)]
+    debug_color: Hsla,
 }
 
 pub struct ActivationHistoryEntry {
@@ -462,6 +464,8 @@ impl Pane {
             diagnostics: Default::default(),
             zoom_out_on_close: true,
             project_item_restoration_data: HashMap::default(),
+            #[cfg(debug_assertions)]
+            debug_color: crate::random_debug_color(),
         }
     }
 
@@ -3199,6 +3203,13 @@ impl Render for Pane {
             .size_full()
             .flex_none()
             .overflow_hidden()
+            .when(
+                cfg!(debug_assertions),
+                |this| {
+                    this.border_2()
+                        .border_color(Color::Custom(self.debug_color))
+                },
+            )
             .on_action(cx.listener(|pane, _: &AlternateFile, window, cx| {
                 pane.alternate_file(window, cx);
             }))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -42,6 +42,8 @@ use gpui::{
     WindowBounds, WindowHandle, WindowId, WindowOptions, action_as, actions, canvas,
     impl_action_as, impl_actions, point, relative, size, transparent_black,
 };
+#[cfg(debug_assertions)]
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 pub use history_manager::*;
 pub use item::{
     FollowableItem, FollowableItemHandle, Item, ItemHandle, ItemSettings, PreviewTabsSettings,
@@ -115,6 +117,37 @@ use crate::persistence::{
 };
 
 pub const SERIALIZATION_THROTTLE_TIME: Duration = Duration::from_millis(200);
+
+#[cfg(debug_assertions)]
+pub fn random_debug_color() -> Hsla {
+    let mut rng = SmallRng::from_entropy();
+    let h: f32 = rng.gen();
+    Hsla { h, s: 1.0, l: 0.5, a: 1.0 }
+}
+
+#[cfg(debug_assertions)]
+pub fn debug_color_name(color: Hsla) -> &'static str {
+    let hue_deg = color.h * 360.0;
+    match hue_deg as i32 {
+        0..=29 => "red",
+        30..=89 => "yellow",
+        90..=149 => "green",
+        150..=209 => "cyan",
+        210..=269 => "blue",
+        270..=329 => "magenta",
+        _ => "red",
+    }
+}
+
+#[cfg(not(debug_assertions))]
+pub fn random_debug_color() -> Hsla {
+    Hsla { h: 0.0, s: 0.0, l: 0.0, a: 0.0 }
+}
+
+#[cfg(not(debug_assertions))]
+pub fn debug_color_name(_: Hsla) -> &'static str {
+    ""
+}
 
 static ZED_WINDOW_SIZE: LazyLock<Option<Size<Pixels>>> = LazyLock::new(|| {
     env::var("ZED_WINDOW_SIZE")
@@ -3406,13 +3439,29 @@ impl Workspace {
                     let panel_focused = dock.read(cx).active_panel()
                         .map(|panel| panel.panel_focus_handle(cx).contains_focused(window, cx))
                         .unwrap_or(false);
-                    let position = dock.read(cx).position();
-                    println!("dock {:?}: dock_focused={}, panel_focused={}", position, dock_focused, panel_focused);
+                    let dock_read = dock.read(cx);
+                    let position = dock_read.position();
+                    #[cfg(debug_assertions)]
+                    let color = debug_color_name(dock_read.debug_color);
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "dock {:?} ({}) : dock_focused={}, panel_focused={}",
+                        position, color, dock_focused, panel_focused
+                    );
+                    #[cfg(not(debug_assertions))]
+                    println!(
+                        "dock {:?}: dock_focused={}, panel_focused={}",
+                        position, dock_focused, panel_focused
+                    );
                     dock_focused || panel_focused
                 });
 
             if let Some(dock) = focused_dock {
-                let position = dock.read(cx).position();
+                let dock_read = dock.read(cx);
+                let position = dock_read.position();
+                #[cfg(debug_assertions)]
+                println!("focused dock {:?} ({})", position, debug_color_name(dock_read.debug_color));
+                #[cfg(not(debug_assertions))]
                 println!("focused dock {:?}", position);
                 if let Some(bounds) = self.bounding_box_for_dock(dock, window, cx) {
                     println!("FOO origin bounds from dock {:?}: {:?}", position, bounds);
@@ -3444,15 +3493,37 @@ impl Workspace {
                     window.focus(&p.focus_handle(cx));
                 }
                 FocusTarget::Dock(d, _, _) => {
-                    let position = d.read(cx).position();
+                    let dock_read = d.read(cx);
+                    let position = dock_read.position();
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "attempting to focus dock {:?} ({})",
+                        position,
+                        debug_color_name(dock_read.debug_color)
+                    );
+                    #[cfg(not(debug_assertions))]
                     println!("attempting to focus dock {:?}", position);
                     // Get both the active panel and its focus handle in one read operation
                     let focus_handle = d.read(cx).active_panel()
                         .map(|panel| panel.panel_focus_handle(cx));
                     if let Some(handle) = focus_handle {
+                        #[cfg(debug_assertions)]
+                        println!(
+                            "focusing panel in dock {:?} ({})",
+                            position,
+                            debug_color_name(dock_read.debug_color)
+                        );
+                        #[cfg(not(debug_assertions))]
                         println!("focusing panel in dock {:?}", position);
-                        handle.focus(window);
+                    handle.focus(window);
                     } else {
+                        #[cfg(debug_assertions)]
+                        println!(
+                            "dock {:?} ({}) has no active panel to focus",
+                            position,
+                            debug_color_name(dock_read.debug_color)
+                        );
+                        #[cfg(not(debug_assertions))]
                         println!("dock {:?} has no active panel to focus", position);
                     }
                 }
@@ -3542,6 +3613,14 @@ impl Workspace {
         let panes = self.center.panes();
         let panes_iter = panes.iter().filter_map(|p| {
             self.bounding_box_for_pane(p).map(|b| {
+                #[cfg(debug_assertions)]
+                println!(
+                    "candidate pane {:?} ({}) -> {:?}",
+                    Entity::entity_id(p),
+                    debug_color_name(p.read(cx).debug_color),
+                    b
+                );
+                #[cfg(not(debug_assertions))]
                 println!("candidate pane {:?} -> {:?}", Entity::entity_id(p), b);
                 FocusTarget::Pane(p, b, p.read(cx).last_visit_ts)
             })
@@ -3556,11 +3635,26 @@ impl Workspace {
             };
 
             if !is_open {
+                #[cfg(debug_assertions)]
+                println!(
+                    "dock {:?} ({}) closed",
+                    position,
+                    debug_color_name(dock_read.debug_color)
+                );
+                #[cfg(not(debug_assertions))]
                 println!("dock {:?} closed", position);
                 return None;
             }
 
             self.bounding_box_for_dock(d, window, cx).map(|b| {
+                #[cfg(debug_assertions)]
+                println!(
+                    "candidate dock {:?} ({}) -> {:?}",
+                    position,
+                    debug_color_name(dock_read.debug_color),
+                    b
+                );
+                #[cfg(not(debug_assertions))]
                 println!("candidate dock {:?} -> {:?}", position, b);
                 FocusTarget::Dock(d, b, last_visit_ts)
             })
@@ -3573,11 +3667,23 @@ impl Workspace {
         for target in panes_iter.chain(docks_iter) {
             let (bounds, ts) = match &target {
                 FocusTarget::Pane(p, b, ts) => {
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "checking pane {:?} ({}) bounds {:?}",
+                        Entity::entity_id(p),
+                        debug_color_name(p.read(cx).debug_color),
+                        b
+                    );
+                    #[cfg(not(debug_assertions))]
                     println!("checking pane {:?} bounds {:?}", Entity::entity_id(p), b);
                     (*b, *ts)
                 }
                 FocusTarget::Dock(d, b, ts) => {
-                    let pos = d.read(cx).position();
+                    let dock_read = d.read(cx);
+                    let pos = dock_read.position();
+                    #[cfg(debug_assertions)]
+                    println!("checking dock {:?} ({}) bounds {:?}", pos, debug_color_name(dock_read.debug_color), b);
+                    #[cfg(not(debug_assertions))]
                     println!("checking dock {:?} bounds {:?}", pos, b);
                     (*b, *ts)
                 }
@@ -3602,8 +3708,27 @@ impl Workspace {
         }
         if let Some(best) = best {
             match &best {
-                FocusTarget::Pane(p, _, _) => println!("best target pane {:?}", Entity::entity_id(p)),
-                FocusTarget::Dock(d, _, _) => println!("best target dock {:?}", d.read(cx).position()),
+                FocusTarget::Pane(p, _, _) => {
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "best target pane {:?} ({})",
+                        Entity::entity_id(p),
+                        debug_color_name(p.read(cx).debug_color)
+                    );
+                    #[cfg(not(debug_assertions))]
+                    println!("best target pane {:?}", Entity::entity_id(p));
+                }
+                FocusTarget::Dock(d, _, _) => {
+                    let dock_read = d.read(cx);
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "best target dock {:?} ({})",
+                        dock_read.position(),
+                        debug_color_name(dock_read.debug_color)
+                    );
+                    #[cfg(not(debug_assertions))]
+                    println!("best target dock {:?}", dock_read.position());
+                }
             }
             return Some(best);
         }
@@ -3623,6 +3748,14 @@ impl Workspace {
         // Rebuild the iterator for circular search
         let panes_iter = panes.iter().filter_map(|p| {
             self.bounding_box_for_pane(p).map(|b| {
+                #[cfg(debug_assertions)]
+                println!(
+                    "circular candidate pane {:?} ({}) -> {:?}",
+                    Entity::entity_id(p),
+                    debug_color_name(p.read(cx).debug_color),
+                    b
+                );
+                #[cfg(not(debug_assertions))]
                 println!("circular candidate pane {:?} -> {:?}", Entity::entity_id(p), b);
                 FocusTarget::Pane(p, b, p.read(cx).last_visit_ts)
             })
@@ -3639,6 +3772,14 @@ impl Workspace {
             }
 
             self.bounding_box_for_dock(d, window, cx).map(|b| {
+                #[cfg(debug_assertions)]
+                println!(
+                    "circular candidate dock {:?} ({}) -> {:?}",
+                    position,
+                    debug_color_name(dock_read.debug_color),
+                    b
+                );
+                #[cfg(not(debug_assertions))]
                 println!("circular candidate dock {:?} -> {:?}", position, b);
                 FocusTarget::Dock(d, b, last_visit_ts)
             })
@@ -3647,11 +3788,28 @@ impl Workspace {
         for target in panes_iter.chain(docks_iter) {
             let (bounds, ts) = match &target {
                 FocusTarget::Pane(p, b, ts) => {
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "circular checking pane {:?} ({}) bounds {:?}",
+                        Entity::entity_id(p),
+                        debug_color_name(p.read(cx).debug_color),
+                        b
+                    );
+                    #[cfg(not(debug_assertions))]
                     println!("circular checking pane {:?} bounds {:?}", Entity::entity_id(p), b);
                     (*b, *ts)
                 }
                 FocusTarget::Dock(d, b, ts) => {
-                    let pos = d.read(cx).position();
+                    let dock_read = d.read(cx);
+                    let pos = dock_read.position();
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "circular checking dock {:?} ({}) bounds {:?}",
+                        pos,
+                        debug_color_name(dock_read.debug_color),
+                        b
+                    );
+                    #[cfg(not(debug_assertions))]
                     println!("circular checking dock {:?} bounds {:?}", pos, b);
                     (*b, *ts)
                 }
@@ -3709,8 +3867,27 @@ impl Workspace {
 
         if let Some(best) = &best {
             match best {
-                FocusTarget::Pane(p, _, _) => println!("circular best target pane {:?}", Entity::entity_id(p)),
-                FocusTarget::Dock(d, _, _) => println!("circular best target dock {:?}", d.read(cx).position()),
+                FocusTarget::Pane(p, _, _) => {
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "circular best target pane {:?} ({})",
+                        Entity::entity_id(p),
+                        debug_color_name(p.read(cx).debug_color)
+                    );
+                    #[cfg(not(debug_assertions))]
+                    println!("circular best target pane {:?}", Entity::entity_id(p));
+                }
+                FocusTarget::Dock(d, _, _) => {
+                    let dock_read = d.read(cx);
+                    #[cfg(debug_assertions)]
+                    println!(
+                        "circular best target dock {:?} ({})",
+                        dock_read.position(),
+                        debug_color_name(dock_read.debug_color)
+                    );
+                    #[cfg(not(debug_assertions))]
+                    println!("circular best target dock {:?}", dock_read.position());
+                }
             }
         } else {
             println!("no circular target found either - staying in place");


### PR DESCRIPTION
## Summary
- generate random debug colors for panes and docks in debug builds
- render panes and docks with colored borders in debug mode
- print color names in debug logs
- avoid double-borrow crash by deferring workspace updates from TerminalPanel

## Testing
- `cargo check -p workspace` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_e_6839f7fd7208832ca1da518b45e22ae2